### PR TITLE
Fix a freeze in the oven code.

### DIFF
--- a/src/main/java/net/blay09/mods/cookingbook/block/TileEntityCookingOven.java
+++ b/src/main/java/net/blay09/mods/cookingbook/block/TileEntityCookingOven.java
@@ -226,9 +226,12 @@ public class TileEntityCookingOven extends TileEntity implements ISidedInventory
                     for (int j : slotsBottom) {
                         ItemStack slotStack = getStackInSlot(j);
                         if (slotStack != null && slotStack.getItem() == transferStack.getItem()) {
-                            firstResultSlot = j;
                             resultSpaceLeft = slotStack.getMaxStackSize() - slotStack.stackSize;
-                            break;
+
+                            if (resultSpaceLeft > 0) {
+                                firstResultSlot = j;
+                                break;
+                            }
                         }
                     }
                     if (firstResultSlot == -1) {

--- a/src/main/java/net/blay09/mods/cookingbook/container/ContainerRecipeBook.java
+++ b/src/main/java/net/blay09/mods/cookingbook/container/ContainerRecipeBook.java
@@ -114,20 +114,20 @@ public class ContainerRecipeBook extends Container {
 						previewSlot.updateVisibleStacks();
 					}
 				}
-				craftMatrixSlots[4].setIngredient(recipe.getCraftMatrix()[0]);
+				craftMatrixSlots[4].setIngredient(recipe.getCraftMatrix().get(0));
 				craftMatrixSlots[4].setEnabled(true);
 				if(!isClientSide) {
 					craftMatrixSlots[4].updateVisibleStacks();
 				}
 			} else {
 				int offset = 0;
-				if (recipe.getCraftMatrix().length <= 3) {
+				if (recipe.getCraftMatrix().size() <= 3) {
 					offset += 3;
 				}
 				for (int i = 0; i < craftMatrix.getSizeInventory(); i++) {
 					int recipeIdx = i - offset;
-					if (recipeIdx >= 0 && recipeIdx < recipe.getCraftMatrix().length) {
-						craftMatrixSlots[i].setIngredient(recipe.getCraftMatrix()[recipeIdx]);
+					if (recipeIdx >= 0 && recipeIdx < recipe.getCraftMatrix().size()) {
+						craftMatrixSlots[i].setIngredient(recipe.getCraftMatrix().get(recipeIdx));
 					} else {
 						craftMatrixSlots[i].setIngredient(null);
 					}
@@ -229,7 +229,7 @@ public class ContainerRecipeBook extends Container {
 			for(int j = 0; j < sourceInventories[i].getSizeInventory(); j++) {
 				ItemStack itemStack = sourceInventories[i].getStackInSlot(j);
 				if(itemStack != null) {
-					for (ItemStack ingredientStack : recipe.getCraftMatrix()[0].getItemStacks()) {
+					for (ItemStack ingredientStack : recipe.getCraftMatrix().get(0).getItemStacks()) {
 						if (FoodRegistry.areItemStacksEqualForCrafting(itemStack, ingredientStack)) {
 							int count = isShiftDown ? Math.min(itemStack.stackSize, ingredientStack.getMaxStackSize()) : 1;
 							TileEntityCookingOven tileEntity = findCookingOven();

--- a/src/main/java/net/blay09/mods/cookingbook/container/InventoryCraftBook.java
+++ b/src/main/java/net/blay09/mods/cookingbook/container/InventoryCraftBook.java
@@ -18,6 +18,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 
+import java.util.List;
+
 public class InventoryCraftBook extends InventoryCrafting {
 
     private final int[] sourceInventories = new int[9];
@@ -31,7 +33,7 @@ public class InventoryCraftBook extends InventoryCrafting {
     }
 
     public IRecipe prepareRecipe(EntityPlayer player, FoodRecipe recipe) {
-        FoodIngredient[] ingredients = recipe.getCraftMatrix();
+        List<FoodIngredient> ingredients = recipe.getCraftMatrix();
         int[][] usedStackSize = new int[inventories.length][];
         for(int i = 0; i < usedStackSize.length; i++) {
             usedStackSize[i] = new int[inventories[i].getSizeInventory()];
@@ -41,12 +43,12 @@ public class InventoryCraftBook extends InventoryCrafting {
             sourceInventories[i] = -1;
             sourceInventorySlots[i] = -1;
         }
-        for(int i = 0; i < ingredients.length; i++) {
-            if(ingredients[i] != null) {
+        for(int i = 0; i < ingredients.size(); i++) {
+            if(ingredients.get(i) != null) {
                 for(int j = 0; j < inventories.length; j++) {
                     for (int k = 0; k < inventories[j].getSizeInventory(); k++) {
                         ItemStack itemStack = inventories[j].getStackInSlot(k);
-                        if (itemStack != null && ingredients[i].isValidItem(itemStack) && itemStack.stackSize - usedStackSize[j][k] > 0) {
+                        if (itemStack != null && ingredients.get(i).isValidItem(itemStack) && itemStack.stackSize - usedStackSize[j][k] > 0) {
                             usedStackSize[j][k]++;
                             setInventorySlotContents(i, itemStack);
                             sourceInventories[i] = j;

--- a/src/main/java/net/blay09/mods/cookingbook/food/FoodRecipe.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/FoodRecipe.java
@@ -2,12 +2,14 @@ package net.blay09.mods.cookingbook.food;
 
 import net.minecraft.item.ItemStack;
 
+import java.util.List;
+
 public abstract class FoodRecipe {
 
-    protected FoodIngredient[] craftMatrix;
+    protected List<FoodIngredient> craftMatrix;
     protected ItemStack outputItem;
 
-    public FoodIngredient[] getCraftMatrix() {
+    public List<FoodIngredient> getCraftMatrix() {
         return craftMatrix;
     }
 

--- a/src/main/java/net/blay09/mods/cookingbook/food/FoodRegistry.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/FoodRegistry.java
@@ -109,21 +109,21 @@ public class FoodRegistry {
         return foodItems.values();
     }
 
-    public static boolean isAvailableFor(FoodIngredient[] craftMatrix, IInventory[] inventories) {
+    public static boolean isAvailableFor(List<FoodIngredient> craftMatrix, IInventory[] inventories) {
         int[][] usedStackSize = new int[inventories.length][];
         for(int i = 0; i < usedStackSize.length; i++) {
             usedStackSize[i] = new int[inventories[i].getSizeInventory()];
         }
-        boolean[] itemFound = new boolean[craftMatrix.length];
-        for(int i = 0; i < craftMatrix.length; i++) {
-            if(craftMatrix[i] == null || craftMatrix[i].isToolItem()) {
+        boolean[] itemFound = new boolean[craftMatrix.size()];
+        for(int i = 0; i < craftMatrix.size(); i++) {
+            if(craftMatrix.get(i) == null || craftMatrix.get(i).isToolItem()) {
                 itemFound[i] = true;
                 continue;
             }
             for(int j = 0; j < inventories.length; j++) {
                 for (int k = 0; k < inventories[j].getSizeInventory(); k++) {
                     ItemStack itemStack = inventories[j].getStackInSlot(k);
-                    if (itemStack != null && craftMatrix[i].isValidItem(itemStack) && itemStack.stackSize - usedStackSize[j][k] > 0) {
+                    if (itemStack != null && craftMatrix.get(i).isValidItem(itemStack) && itemStack.stackSize - usedStackSize[j][k] > 0) {
                         usedStackSize[j][k]++;
                         itemFound[i] = true;
                         break;

--- a/src/main/java/net/blay09/mods/cookingbook/food/recipe/RemoteCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/recipe/RemoteCraftingFood.java
@@ -6,13 +6,14 @@ import net.blay09.mods.cookingbook.food.FoodRecipe;
 import net.blay09.mods.cookingbook.food.FoodIngredient;
 import net.minecraft.item.ItemStack;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class RemoteCraftingFood extends FoodRecipe {
 
     private final boolean isSmeltingRecipe;
 
-    public RemoteCraftingFood(ItemStack outputItem, FoodIngredient[] craftMatrix, boolean isSmeltingRecipe) {
+    public RemoteCraftingFood(ItemStack outputItem, List<FoodIngredient> craftMatrix, boolean isSmeltingRecipe) {
         this.outputItem = outputItem;
         this.craftMatrix = craftMatrix;
         this.isSmeltingRecipe = isSmeltingRecipe;
@@ -25,14 +26,17 @@ public class RemoteCraftingFood extends FoodRecipe {
 
     public static RemoteCraftingFood read(ByteBuf buf) {
         ItemStack outputItem = ByteBufUtils.readItemStack(buf);
-        FoodIngredient[] craftMatrix = new FoodIngredient[buf.readByte()];
-        for(int k = 0; k < craftMatrix.length; k++) {
-            ItemStack[] itemStacks = new ItemStack[buf.readByte()];
-            for(int l = 0; l < itemStacks.length; l++) {
+
+        byte ingredientCount = buf.readByte();
+        List<FoodIngredient> craftMatrix = new ArrayList<FoodIngredient>(ingredientCount);
+        for(int k = 0; k < ingredientCount; k++) {
+            byte stackCount = buf.readByte();
+            ItemStack[] itemStacks = new ItemStack[stackCount];
+            for(int l = 0; l < stackCount; l++) {
                 itemStacks[l] = ByteBufUtils.readItemStack(buf);
             }
             boolean isOptional = buf.readBoolean();
-            craftMatrix[k] = new FoodIngredient(itemStacks, isOptional);
+            craftMatrix.add(new FoodIngredient(itemStacks, isOptional));
         }
         boolean isSmeltingRecipe = buf.readBoolean();
         return new RemoteCraftingFood(outputItem, craftMatrix, isSmeltingRecipe);
@@ -40,7 +44,7 @@ public class RemoteCraftingFood extends FoodRecipe {
 
     public static void write(ByteBuf buf, FoodRecipe recipe) {
         ByteBufUtils.writeItemStack(buf, recipe.getOutputItem());
-        buf.writeByte(recipe.getCraftMatrix().length);
+        buf.writeByte(recipe.getCraftMatrix().size());
         for(FoodIngredient ingredient : recipe.getCraftMatrix()) {
             buf.writeByte(ingredient.getItemStacks().length);
             for(ItemStack ingredientStack : ingredient.getItemStacks()) {

--- a/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapedCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapedCraftingFood.java
@@ -5,16 +5,18 @@ import net.blay09.mods.cookingbook.food.FoodIngredient;
 import net.blay09.mods.cookingbook.food.FoodRecipe;
 import net.minecraft.item.crafting.ShapedRecipes;
 
+import java.util.ArrayList;
+
 public class ShapedCraftingFood extends FoodRecipe {
 
     public ShapedCraftingFood(ShapedRecipes recipe) {
         this.outputItem = recipe.getRecipeOutput();
-        craftMatrix = new FoodIngredient[recipe.getRecipeSize()];
+        craftMatrix = new ArrayList<FoodIngredient>();
+
         for(int i = 0; i < recipe.recipeItems.length; i++) {
             if(recipe.recipeItems[i] != null) {
-
                 boolean isToolItem = PamsHarvestcraft.isToolItem(recipe.recipeItems[i]);
-                craftMatrix[i] = new FoodIngredient(recipe.recipeItems[i].copy(), isToolItem);
+                craftMatrix.add(new FoodIngredient(recipe.recipeItems[i].copy(), isToolItem));
             }
         }
     }

--- a/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapedOreCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapedOreCraftingFood.java
@@ -5,19 +5,23 @@ import net.blay09.mods.cookingbook.food.FoodRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ShapedOreCraftingFood extends FoodRecipe {
 
     public ShapedOreCraftingFood(ShapedOreRecipe recipe) {
         this.outputItem = recipe.getRecipeOutput();
-        this.craftMatrix = new FoodIngredient[recipe.getRecipeSize()];
+        this.craftMatrix = new ArrayList<FoodIngredient>();
         for(int i = 0; i < recipe.getInput().length; i++) {
             Object input = recipe.getInput()[i];
+            if (input == null)
+                continue;
+
             if(input instanceof ItemStack) {
-                craftMatrix[i] = new FoodIngredient((ItemStack) input, false);
+                craftMatrix.add(new FoodIngredient((ItemStack) input, false));
             } else if(input instanceof List) {
-                craftMatrix[i] = new FoodIngredient(((List<ItemStack>) input).toArray(new ItemStack[((List<ItemStack>) input).size()]), false);
+                craftMatrix.add(new FoodIngredient(((List<ItemStack>) input).toArray(new ItemStack[((List<ItemStack>) input).size()]), false));
             }
         }
     }

--- a/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapelessCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapelessCraftingFood.java
@@ -6,14 +6,19 @@ import net.blay09.mods.cookingbook.food.FoodRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ShapelessRecipes;
 
+import java.util.ArrayList;
+
 public class ShapelessCraftingFood extends FoodRecipe {
 
     public ShapelessCraftingFood(ShapelessRecipes recipe) {
         this.outputItem = recipe.getRecipeOutput();
-        this.craftMatrix = new FoodIngredient[recipe.getRecipeSize()];
+        this.craftMatrix = new ArrayList<FoodIngredient>();
         for(int i = 0; i < recipe.recipeItems.size(); i++) {
+            if (recipe.recipeItems.get(i) == null)
+                continue;
+
             boolean isToolItem = PamsHarvestcraft.isToolItem((ItemStack) recipe.recipeItems.get(i));
-            craftMatrix[i] = new FoodIngredient(((ItemStack) recipe.recipeItems.get(i)).copy(), isToolItem);
+            craftMatrix.add(new FoodIngredient(((ItemStack) recipe.recipeItems.get(i)).copy(), isToolItem));
         }
     }
 

--- a/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapelessOreCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/recipe/ShapelessOreCraftingFood.java
@@ -12,12 +12,16 @@ public class ShapelessOreCraftingFood extends FoodRecipe {
 
     public ShapelessOreCraftingFood(ShapelessOreRecipe recipe) {
         this.outputItem = recipe.getRecipeOutput();
-        this.craftMatrix = new FoodIngredient[recipe.getRecipeSize()];
+        this.craftMatrix = new ArrayList<FoodIngredient>();
         for(int i = 0; i < recipe.getInput().size(); i++) {
             Object input = recipe.getInput().get(i);
+
+            if (input == null)
+                continue;
+
             if(input instanceof ItemStack) {
                 boolean isToolItem = PamsHarvestcraft.isToolItem((ItemStack) input);
-                craftMatrix[i] = new FoodIngredient(((ItemStack) input), isToolItem);
+                craftMatrix.add(new FoodIngredient(((ItemStack) input), isToolItem));
             } else if(input instanceof ArrayList) {
                 List<ItemStack> list = (List<ItemStack>) input;
                 boolean toolFound = false;
@@ -26,7 +30,7 @@ public class ShapelessOreCraftingFood extends FoodRecipe {
                         toolFound = true;
                     }
                 }
-                craftMatrix[i] = new FoodIngredient(list.toArray(new ItemStack[list.size()]), toolFound);
+                craftMatrix.add(new FoodIngredient(list.toArray(new ItemStack[list.size()]), toolFound));
             }
         }
     }

--- a/src/main/java/net/blay09/mods/cookingbook/food/recipe/SmeltingFood.java
+++ b/src/main/java/net/blay09/mods/cookingbook/food/recipe/SmeltingFood.java
@@ -4,11 +4,14 @@ import net.blay09.mods.cookingbook.food.FoodIngredient;
 import net.blay09.mods.cookingbook.food.FoodRecipe;
 import net.minecraft.item.ItemStack;
 
+import java.util.ArrayList;
+
 public class SmeltingFood extends FoodRecipe {
 
     public SmeltingFood(ItemStack outputItem, ItemStack sourceStack) {
         this.outputItem = outputItem;
-        this.craftMatrix = new FoodIngredient[] { new FoodIngredient(sourceStack, false) };
+        this.craftMatrix = new ArrayList<FoodIngredient>();
+        this.craftMatrix.add(new FoodIngredient(sourceStack, false));
     }
 
     @Override


### PR DESCRIPTION
Previously, a freeze would occur when cooking finished on an item which
already had a full stack in the oven output.  The slot # to use would
initially be set to the full one and then would get into the while loop
which attempts to split up the outputting items and get into an infinite
loop because its chosen stack was full and the while loop can't handle
that.

This prevents the code from committing to a full output slot.