### PR TITLE
Fix Quark dropoff support.

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/tile/TileCounter.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/tile/TileCounter.java
@@ -24,7 +24,7 @@ import vazkii.quark.base.handler.IDropoffManager;
 
 import javax.annotation.Nullable;
 
-@Optional.Interface(modid = "Quark", iface = "vazkii.quark.base.handler.IDropoffManager", striprefs = true)
+@Optional.Interface(modid = "quark", iface = "vazkii.quark.base.handler.IDropoffManager", striprefs = true)
 public class TileCounter extends TileEntity implements ITickable, IDropoffManager {
 
     private final ItemStackHandler itemHandler = new ItemStackHandler(27) {
@@ -172,7 +172,7 @@ public class TileCounter extends TileEntity implements ITickable, IDropoffManage
     }
 
     @Override
-    @Optional.Method(modid = "Quark")
+    @Optional.Method(modid = "quark")
     public boolean acceptsDropoff() {
         return true;
     }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/tile/TileFridge.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/tile/TileFridge.java
@@ -25,7 +25,7 @@ import vazkii.quark.base.handler.IDropoffManager;
 
 import javax.annotation.Nullable;
 
-@Optional.Interface(modid = "Quark", iface = "vazkii.quark.base.handler.IDropoffManager", striprefs = true)
+@Optional.Interface(modid = "quark", iface = "vazkii.quark.base.handler.IDropoffManager", striprefs = true)
 public class TileFridge extends TileEntity implements ITickable, IDropoffManager {
 
     private final ItemStackHandler itemHandler = new ItemStackHandler(27) {
@@ -177,7 +177,7 @@ public class TileFridge extends TileEntity implements ITickable, IDropoffManager
     }
 
     @Override
-    @Optional.Method(modid = "Quark")
+    @Optional.Method(modid = "quark")
     public boolean acceptsDropoff() {
         return true;
     }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/tile/TileSpiceRack.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/tile/TileSpiceRack.java
@@ -11,12 +11,15 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
+import vazkii.quark.base.handler.IDropoffManager;
 
 import javax.annotation.Nullable;
 
-public class TileSpiceRack extends TileEntity {
+@Optional.Interface(modid = "quark", iface = "vazkii.quark.base.handler.IDropoffManager", striprefs = true)
+public class TileSpiceRack extends TileEntity implements IDropoffManager {
 
     private final ItemStackHandler itemHandler = new ItemStackHandler(9) {
         @Override
@@ -84,5 +87,11 @@ public class TileSpiceRack extends TileEntity {
     @Override
     public boolean shouldRefresh(World world, BlockPos pos, IBlockState oldState, IBlockState newSate) {
         return oldState.getBlock() != newSate.getBlock();
+    }
+
+    @Override
+    @Optional.Method(modid = "quark")
+    public boolean acceptsDropoff() {
+        return true;
     }
 }


### PR DESCRIPTION
This should address #217.

Quark's modid changed to lowercase in 1.11, so the interfaces were
getting deleted.  While I was at it, I added it to the spice rack.