### PR TITLE
Fix recipe book with foods with different metadata

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/SimpleAddon.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/SimpleAddon.java
@@ -17,7 +17,6 @@ public class SimpleAddon {
 
 	private final String modId;
 	private final List<String> additionalRecipes = Lists.newArrayList();
-	private final List<String> wildcardRecipes = Lists.newArrayList();
 
 	public SimpleAddon(String modId) {
 		this.modId = modId;
@@ -33,22 +32,11 @@ public class SimpleAddon {
 				event.registerNonFoodRecipe(itemStack);
 			}
 		}
-                for(String s : wildcardRecipes) {
-			ItemStack itemStack = getModItemStack(s);
-			if(!itemStack.isEmpty()) {
-                                itemStack.setItemDamage(OreDictionary.WILDCARD_VALUE);
-				event.registerNonFoodRecipe(itemStack);
-			}
-                }
 	}
 
 	public void addNonFoodRecipe(String... names) {
 		Collections.addAll(additionalRecipes, names);
 	}
-
-        public void addWildcardNonFoodRecipe(String... names) {
-                Collections.addAll(wildcardRecipes, names);
-        }
 
 	public void addTool(String... names) {
 		for(String name : names) {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/VanillaFoodPantryAddon.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/VanillaFoodPantryAddon.java
@@ -47,16 +47,9 @@ public class VanillaFoodPantryAddon extends SimpleAddon {
         "skewers_wood",
     };
 
-    private static final String[] WILDCARD_RECIPES = new String[] {
-        "dough_ball",
-        "foodpowder",
-        "meat_portion",
-        "nuggets",
-        "water_bottle",
-    };
-
     private static final String[] TOOLS = new String[] {
         "bit_pipette",
+        "fermenting_bucket",
         "flint_cutter",
         "whisk",
         "weighted_plate"
@@ -70,7 +63,6 @@ public class VanillaFoodPantryAddon extends SimpleAddon {
         super("vanillafoodpantry");
 
         addNonFoodRecipe(ADDITIONAL_RECIPES);
-        addWildcardNonFoodRecipe(WILDCARD_RECIPES);
         addTool(TOOLS);
 
         CookingForBlockheadsAPI.addWaterItem(getModItemStack(FRESH_WATER_ITEM));

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
@@ -215,12 +215,12 @@ public class ContainerRecipeBook extends Container {
 	}
 
 	public void findAndSendItemList() {
-		Map<ResourceLocation, FoodRecipeWithStatus> statusMap = Maps.newHashMap();
+		Map<CookingRegistry.ItemID, FoodRecipeWithStatus> statusMap = Maps.newHashMap();
 		List<IKitchenItemProvider> inventories = CookingRegistry.getItemProviders(multiBlock, player.inventory);
 		keyLoop:
-		for (ResourceLocation key : CookingRegistry.getFoodRecipes().keySet()) {
+		for (CookingRegistry.ItemID key : CookingRegistry.getFoodRecipes().keySet()) {
 			RecipeStatus bestStatus = null;
-			for (FoodRecipe recipe : CookingRegistry.getFoodRecipes().get(key)) {
+			for (FoodRecipe recipe : CookingRegistry.getFoodRecipes(key)) {
 				RecipeStatus thisStatus = CookingRegistry.getRecipeStatus(recipe, inventories);
 				if (noFilter || thisStatus != RecipeStatus.MISSING_INGREDIENTS) {
 					if (bestStatus == null || thisStatus.ordinal() > bestStatus.ordinal()) {


### PR DESCRIPTION
The problem I was trying to solve with the wildcards in the VanillaFoodPantry support turned out to not do quite what I wanted it to do; some digging revealed that metadata was being thrown out before being handed to the recipe book.  As such this tears out the wildcard work (and adds a tool I forgot about!) and amends the recipe registry so that it respects metadata.