### PR TITLE
add new HarvestCraft 1.12r items

### DIFF
--- a/src/main/resources/assets/cookingforblockheads/compat/harvestcraft.json
+++ b/src/main/resources/assets/cookingforblockheads/compat/harvestcraft.json
@@ -42,7 +42,17 @@
       "cherrycheesecakeitem",
       "pineappleupsidedowncakeitem",
       "chocolatesprinklecakeitem",
-      "redvelvetcakeitem"
+      "redvelvetcakeitem",
+      "groundbeefitem",
+      "groundchickenitem",
+      "groundduckitem",
+      "groundfishitem",
+      "groundmuttonitem",
+      "groundporkitem",
+      "groundrabbititem",
+      "groundturkeyitem",
+      "groundvenisonitem"
+
     ]
   },
   "tools": [
@@ -64,7 +74,8 @@
   "oven_recipes": {
     "turkeyrawitem": "turkeycookeditem",
     "rabbitrawitem": "rabbitcookeditem",
-    "venisonrawitem": "venisoncookeditem"
+    "venisonrawitem": "venisoncookeditem",
+    "duckrawitem": "duckcookeditem"
   },
   "oven_fuel": [
     {


### PR DESCRIPTION
This should cover the new meat-trap duck meat (for the oven) and  all the new ground meats.