### PR TITLE
Adding support for inventories from StorageDrawers mod.

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
@@ -1,0 +1,176 @@
+package net.blay09.mods.cookingforblockheads.compat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.blay09.mods.cookingforblockheads.CookingForBlockheads;
+import net.blay09.mods.cookingforblockheads.api.capability.CapabilityKitchenConnector;
+import net.blay09.mods.cookingforblockheads.api.capability.CapabilityKitchenItemProvider;
+import net.blay09.mods.cookingforblockheads.api.capability.IKitchenItemProvider;
+import net.blay09.mods.cookingforblockheads.api.capability.KitchenItemProvider;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemStackHandler;
+
+public class CompatCapabilityLoader {
+    private final static List<Class<? extends TileEntity>> dynKitchenItemProviderEntities = new ArrayList<Class<? extends TileEntity>>();
+    private final static List<Class<? extends TileEntity>> kitchenItemProviderEntities = new ArrayList<Class<? extends TileEntity>>();
+    private final static List<Class<? extends TileEntity>> kitchenConnectorEntities = new ArrayList<Class<? extends TileEntity>>();
+    private final static ItemStackHandler emptyItemHandler = new ItemStackHandler(0);
+    private final static CompatCapabilityLoader loader = new CompatCapabilityLoader();
+    private static boolean registered = false;
+
+    public static void register() {
+        if (registered)
+            return;
+        MinecraftForge.EVENT_BUS.register(loader);
+        registered = true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addTileEntityClass(final String className, final List<Class<? extends TileEntity>> list) {
+        try {
+            Class<?> c = Class.forName(className);
+            if (TileEntity.class.isAssignableFrom(c)) {
+                list.add((Class<? extends TileEntity>) c);
+                register();
+            } else
+                CookingForBlockheads.logger.warn("Incompatible TileEntity class: {}", className);
+        } catch (ClassNotFoundException e) {
+            CookingForBlockheads.logger.warn("TileEntity class not found: {}", className);
+        }
+    }
+
+    public static void addDynamicKitchenItemProviderClass(String className) {
+        addTileEntityClass(className, dynKitchenItemProviderEntities);
+    }
+
+    public static void addKitchenItemProviderClass(String className) {
+        addTileEntityClass(className, kitchenItemProviderEntities);
+    }
+
+    public static void addKitchenConnectorClass(String className) {
+        addTileEntityClass(className, kitchenConnectorEntities);
+    }
+
+    private final static ResourceLocation capabilityKitchenItemProvider = new ResourceLocation(CookingForBlockheads.MOD_ID, CapabilityKitchenItemProvider.CAPABILITY.getName());
+    private final static ResourceLocation capabilityKitchenConnector = new ResourceLocation(CookingForBlockheads.MOD_ID, CapabilityKitchenItemProvider.CAPABILITY.getName());
+    @SubscribeEvent
+    public void tileEntity(AttachCapabilitiesEvent<TileEntity> event) {
+        final TileEntity entity = event.getObject();
+        for (final Class<? extends TileEntity> c: kitchenItemProviderEntities) {
+            if (! c.isInstance(entity))
+                continue;
+            event.addCapability(capabilityKitchenItemProvider, crateItemCapabilityProvider(entity, false));
+            return;
+        }
+        for (final Class<? extends TileEntity> c: dynKitchenItemProviderEntities) {
+            if (! c.isInstance(entity))
+                continue;
+            event.addCapability(capabilityKitchenItemProvider, crateItemCapabilityProvider(entity, true));
+            return;
+        }
+        for (final Class<? extends TileEntity> c: kitchenConnectorEntities) {
+            if (! c.isInstance(entity))
+                continue;
+            event.addCapability(capabilityKitchenConnector,
+                    new ICapabilityProvider() {
+                        @Override
+                        public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+                            return CapabilityKitchenConnector.CAPABILITY == capability;
+                        }
+                        @Override
+                        public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+                            return null;
+                        }
+                    });
+            return;
+        }
+    }
+
+    private ICapabilityProvider crateItemCapabilityProvider(final TileEntity entity, final boolean dynamic) {
+        return new ICapabilityProvider() {
+            private KitchenItemProvider kitchenProvider = null;
+            private IItemHandler itemHandler = null;
+
+            @Override
+            public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+                return CapabilityKitchenItemProvider.CAPABILITY == capability;
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+                if (CapabilityKitchenItemProvider.CAPABILITY != capability)
+                    return null;
+                if (itemHandler != null)
+                    return (T) kitchenProvider;
+
+                if (kitchenProvider == null)
+                    kitchenProvider = dynamic ? new DynamicKitchenItemProvider(emptyItemHandler) : new KitchenItemProvider(emptyItemHandler);
+
+                final IItemHandler handler;
+                if (entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null))
+                    handler = entity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
+                else if (entity instanceof IItemHandler)
+                    handler = (IItemHandler) entity;
+                else
+                    return (T) kitchenProvider;
+
+                itemHandler = handler;
+                kitchenProvider.setItemHandler(handler);
+                return (T) kitchenProvider;
+            }
+        };
+    }
+
+    public static final class DynamicKitchenItemProvider extends KitchenItemProvider {
+        private IItemHandler itemHandler;
+        private int stackSize = 0;
+        private boolean checked = false;
+
+        public DynamicKitchenItemProvider(IItemHandler itemHandler) {
+            setItemHandler(itemHandler);
+        }
+
+        @Override
+        public void setItemHandler(IItemHandler itemHandler) {
+            final int newSize = itemHandler.getSlots();
+            if (itemHandler != this.itemHandler) {
+                this.itemHandler = itemHandler;
+                stackSize = newSize;
+                super.setItemHandler(itemHandler);
+            } else if (newSize > stackSize) {
+                stackSize = newSize;
+                super.setItemHandler(itemHandler);
+            }
+        }
+
+        @Override
+        public void resetSimulation() {
+            checked = false;
+            super.resetSimulation();
+        }
+
+        @Override
+        public ItemStack useItemStack(int slot, int amount, boolean simulate, List<IKitchenItemProvider> inventories, boolean requireBucket) {
+            if (simulate && (! checked)) {
+                if (stackSize < itemHandler.getSlots()) {
+                    setItemHandler(itemHandler);
+                }
+                checked = true;
+            }
+            return super.useItemStack(slot, amount, simulate, inventories, requireBucket);
+        }
+    }
+
+}

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
@@ -70,7 +70,6 @@ public class CompatCapabilityLoader {
 
         final CapabilityType type = tilesClasses.get(entityClass);
         if (type == null) {
-            CookingForBlockheads.logger.info("DEBUGME -- Un known class: " + entityClass);
             return;
         }
         switch (type) {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
@@ -73,7 +73,6 @@ public class CompatCapabilityLoader {
             event.addCapability(connectorResourceKey, connectorCapabilityProvider);
             return;
         }
-        CookingForBlockheads.logger.warn("Entity class not handled: " + entityClass);
     }
 
     private static final class KitchenConnectorCapabilityProvider implements ICapabilityProvider {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/JsonCompatLoader.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/JsonCompatLoader.java
@@ -184,19 +184,12 @@ public class JsonCompatLoader {
             }
         }
         JsonObject tilesObject = JsonUtils.getJsonObject(root, "tiles", EMPTY_OBJECT);
-        JsonArray tiles = JsonUtils.getJsonArray(tilesObject, "dynamicKitchenItemProviders", EMPTY_ARRAY);
+        JsonArray tiles = JsonUtils.getJsonArray(tilesObject, "kitchenItemProviders", EMPTY_ARRAY);
         for (JsonElement element : tiles) {
             if (!element.isJsonPrimitive()) {
                 throw new JsonSyntaxException("Expected array elements to be a primitive, got " + element);
             }
-            CompatCapabilityLoader.addDynamicKitchenItemProviderClass(element.getAsString());
-        }
-        tiles = JsonUtils.getJsonArray(tilesObject, "kitchenItemProviders", EMPTY_ARRAY);
-        for (JsonElement element : tiles) {
-            if (!element.isJsonPrimitive()) {
-                throw new JsonSyntaxException("Expected array elements to be a primitive, got " + element);
-            }
-            CompatCapabilityLoader.addDynamicKitchenItemProviderClass(element.getAsString());
+            CompatCapabilityLoader.addKitchenItemProviderClass(element.getAsString());
         }
         tiles = JsonUtils.getJsonArray(tilesObject, "kitchenConnectors", EMPTY_ARRAY);
         for (JsonElement element : tiles) {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/JsonCompatLoader.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/JsonCompatLoader.java
@@ -183,6 +183,28 @@ public class JsonCompatLoader {
                 CookingForBlockheadsAPI.addToasterHandler(input, itemStack -> output);
             }
         }
+        JsonObject tilesObject = JsonUtils.getJsonObject(root, "tiles", EMPTY_OBJECT);
+        JsonArray tiles = JsonUtils.getJsonArray(tilesObject, "dynamicKitchenItemProviders", EMPTY_ARRAY);
+        for (JsonElement element : tiles) {
+            if (!element.isJsonPrimitive()) {
+                throw new JsonSyntaxException("Expected array elements to be a primitive, got " + element);
+            }
+            CompatCapabilityLoader.addDynamicKitchenItemProviderClass(element.getAsString());
+        }
+        tiles = JsonUtils.getJsonArray(tilesObject, "kitchenItemProviders", EMPTY_ARRAY);
+        for (JsonElement element : tiles) {
+            if (!element.isJsonPrimitive()) {
+                throw new JsonSyntaxException("Expected array elements to be a primitive, got " + element);
+            }
+            CompatCapabilityLoader.addDynamicKitchenItemProviderClass(element.getAsString());
+        }
+        tiles = JsonUtils.getJsonArray(tilesObject, "kitchenConnectors", EMPTY_ARRAY);
+        for (JsonElement element : tiles) {
+            if (!element.isJsonPrimitive()) {
+                throw new JsonSyntaxException("Expected array elements to be a primitive, got " + element);
+            }
+            CompatCapabilityLoader.addKitchenConnectorClass(element.getAsString());
+        }
     }
 
     private static ItemStack[] parseItemStacks(String modId, JsonElement element) {

--- a/src/main/resources/assets/cookingforblockheads/compat/storagedrawers.json
+++ b/src/main/resources/assets/cookingforblockheads/compat/storagedrawers.json
@@ -1,0 +1,12 @@
+{
+  "modid": "storagedrawers",
+  "tiles": {
+    "kitchenConnectors" : [
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave",
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController"
+    ],
+    "kitchenItemProviders" : [
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers"
+    ]
+  }
+}

--- a/src/main/resources/assets/cookingforblockheads/compat/storagedrawers.json
+++ b/src/main/resources/assets/cookingforblockheads/compat/storagedrawers.json
@@ -3,10 +3,14 @@
   "tiles": {
     "kitchenConnectors" : [
       "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntitySlave",
-      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController"
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController",
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityTrim"
     ],
     "kitchenItemProviders" : [
-      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawers"
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard$Slot1",
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard$Slot2",
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard$Slot4",
+      "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp"
     ]
   }
 }


### PR DESCRIPTION
The feature consist in:
- adding KitchenItemProvider capability to drawers blocks,
- adding KitchenConnector capability to controllers and slave controllers blocks

It is to note that controllers from StorageDrawers have a 5 second refresh delay which makes them not suitable to be directly used as item providers.

I tested the this feature with both Minecraft 1.12 and 1.10 versions.
