### PR TITLE
Ensuring stackSize of ItemStack is compatible with network encoding

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/network/message/ByteBufUtils.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/network/message/ByteBufUtils.java
@@ -1,0 +1,26 @@
+package net.blay09.mods.cookingforblockheads.network.message;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.item.ItemStack;
+
+public class ByteBufUtils {
+
+    public final static ItemStack readItemStack(final ByteBuf from) {
+        return net.minecraftforge.fml.common.network.ByteBufUtils.readItemStack(from);
+    }
+
+    public final static void writeItemStack(final ByteBuf to, final ItemStack stack) {
+        // Function net.minecraft.network.PacketBuffer.writeItemStack()
+        // encodes "stackSize" on a single byte. This creates encoding
+        // and decoding issue when value (modulo 256) is greater than 127
+        final int count = stack.getCount();
+        if (count < 128) {
+            net.minecraftforge.fml.common.network.ByteBufUtils.writeItemStack(to, stack);
+        } else {
+            stack.setCount(127);
+            net.minecraftforge.fml.common.network.ByteBufUtils.writeItemStack(to, stack);
+            stack.setCount(count);
+        }
+    }
+
+}

--- a/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageCraftRecipe.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageCraftRecipe.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import net.blay09.mods.cookingforblockheads.registry.RecipeType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 public class MessageCraftRecipe implements IMessage {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageItemList.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageItemList.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
 import net.blay09.mods.cookingforblockheads.api.RecipeStatus;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageRecipes.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageRecipes.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithIngredients;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 import java.util.List;

--- a/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageRequestRecipes.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageRequestRecipes.java
@@ -2,7 +2,6 @@ package net.blay09.mods.cookingforblockheads.network.message;
 
 import io.netty.buffer.ByteBuf;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 public class MessageRequestRecipes implements IMessage {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/FoodRecipeWithIngredients.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/FoodRecipeWithIngredients.java
@@ -2,9 +2,9 @@ package net.blay09.mods.cookingforblockheads.registry;
 
 import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
+import net.blay09.mods.cookingforblockheads.network.message.ByteBufUtils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraftforge.fml.common.network.ByteBufUtils;
 
 import java.util.List;
 


### PR DESCRIPTION
Found a bug while playing with the StorageDrawers support.
When a stack (module 256) has a size greater than 127, the item appears as a block of air in the cooking table recipe and crafting is impossible.
This is caused by Minecraft's function `PacketBuffer.writeItemStack()` that encode stackSize on a single (signed) byte.

The solution proposed here is the easiest one I found, that only fakes the `stackSize` sent over the network (and keep message compatibility).
There could be other ways to correct this issue, but they would break message compatibility with previous client/server mod version, like:
- encoding ItemStack manually using a `short` or an `int`
- no longer encoding ItemStack and only sending minimum required elements (I am not sure of that, but  stackSize does not look like being used).


Regards,

Vlaeh