### PR TITLE
Correcting StorageDrawers Trim block support

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/KitchenMultiBlock.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/KitchenMultiBlock.java
@@ -4,8 +4,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import net.blay09.mods.cookingforblockheads.api.IKitchenMultiBlock;
 import net.blay09.mods.cookingforblockheads.api.capability.*;
-import net.blay09.mods.cookingforblockheads.block.ModBlocks;
 import net.blay09.mods.cookingforblockheads.registry.CookingRegistry;
+import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -16,11 +16,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.wrapper.InvWrapper;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 public class KitchenMultiBlock implements IKitchenMultiBlock {
-
+    private final static ArrayList<Block> blockConnectors = new ArrayList<Block>();
     private final Set<BlockPos> checkedPos = Sets.newHashSet();
     private final List<IKitchenItemProvider> itemProviderList = Lists.newArrayList();
     private final List<IKitchenSmeltingProvider> smeltingProviderList = Lists.newArrayList();
@@ -50,7 +51,7 @@ public class KitchenMultiBlock implements IKitchenMultiBlock {
                     }
                 } else {
                     IBlockState state = world.getBlockState(position);
-                    if (state.getBlock() == ModBlocks.kitchenFloor) {
+                    if (blockConnectors.contains(state.getBlock())) {
                         findNeighbourKitchenBlocks(world, position);
                     }
                 }
@@ -111,4 +112,7 @@ public class KitchenMultiBlock implements IKitchenMultiBlock {
         return smeltingProviderList.size() > 0;
     }
 
+    public static void registerConnectorBlock(final Block block) {
+        blockConnectors.add(block);
+    }
 }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/block/ModBlocks.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/block/ModBlocks.java
@@ -1,6 +1,8 @@
 package net.blay09.mods.cookingforblockheads.block;
 
 import com.google.common.collect.Lists;
+
+import net.blay09.mods.cookingforblockheads.KitchenMultiBlock;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.Item;
@@ -47,6 +49,7 @@ public class ModBlocks {
         kitchenFloor = registerBlock(registry, new BlockKitchenFloor());
         fruitBasket = registerBlock(registry, new BlockFruitBasket());
         cuttingBoard = registerBlock(registry, new BlockCuttingBoard());
+        KitchenMultiBlock.registerConnectorBlock(kitchenFloor);
     }
 
     private static Block registerBlock(IForgeRegistry<Block> registry, Block block) {

--- a/src/main/resources/assets/cookingforblockheads/compat/storagedrawers.json
+++ b/src/main/resources/assets/cookingforblockheads/compat/storagedrawers.json
@@ -11,6 +11,9 @@
       "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard$Slot2",
       "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard$Slot4",
       "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersComp"
+    ],
+    "multiBlockConnectors" : [
+      "trim"
     ]
   }
 }


### PR DESCRIPTION
Correcting StorageDrawer to fully support Trim blocks as kitchen connectors.
KitchenMultiBlock class is now using a list of connector blocks.

Connector blocks are configured in the compatibility JSON files as 
```
  "tiles": {
    "multiBlockConnectors" : [
      "block_name"
    ]
  }
```
Load is made from Forge's block registry using "modid" and "block_name".

Vlaeh