### PR TITLE
Fixed fridge not rendering items when flipped

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/client/render/FridgeRenderer.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/client/render/FridgeRenderer.java
@@ -122,7 +122,7 @@ public class FridgeRenderer extends TileEntitySpecialRenderer<TileFridge> {
         GlStateManager.popMatrix();*/
 
         // Render the fridge content if the door is open
-        if (doorAngle > 0f) {
+        if (doorAngle != 0f) {
             RenderItem itemRenderer = Minecraft.getMinecraft().getRenderItem();
             GlStateManager.pushMatrix();
             GlStateManager.color(1f, 1f, 1f, 1f);


### PR DESCRIPTION
Fixes #303 and #374 
The value of the door is negative when the fridge is flipped. 

![image](https://user-images.githubusercontent.com/1357800/57308478-b56b2e00-70e6-11e9-8840-8244ccc5294f.png)
