### PR TITLE
fix sink extraction issues fixes #498

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/tile/SinkTileEntity.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/tile/SinkTileEntity.java
@@ -72,7 +72,13 @@ public class SinkTileEntity extends TileEntity {
                 return resource.copy();
             }
 
-            return super.drain(resource, action);
+            //Copied from FluidTank#drain as the parent's drain function needs to be called not the one from this class
+            if (resource.isEmpty() || !resource.isFluidEqual(fluid))
+            {
+                return FluidStack.EMPTY;
+            }
+
+            return super.drain(resource.getAmount(), action);
         }
 
         @Override
@@ -84,6 +90,14 @@ public class SinkTileEntity extends TileEntity {
             return super.drain(maxDrain, action);
         }
 
+        @Override
+        public int fill(FluidStack resource, FluidAction action) {
+            if (!CookingForBlockheadsConfig.COMMON.sinkRequiresWater.get()) {
+                return resource.getAmount();
+            }
+
+            return super.fill(resource, action);
+        }
     }
 
     private static class SinkItemProvider extends DefaultKitchenItemProvider {


### PR DESCRIPTION
We keep getting reports with people extracting water instead of the request fluid through RS, so I figured a PR might speed up fixing this? ;)

This fixes the issue without changing what I think was the intended behavior.

If Sink requires water is set to true:
- Sink behaves like a simple tank

If Sink requires water is set to false:
- any fluid inserted will be voided
- extraction provides water or nothing* if a different fluid is requested 

*unless the config was changed and a fluid was inserted before that

