### PR TITLE
Fixed Fridge duping with Create

### DIFF
--- a/src/main/resources/data/create/tags/blocks/brittle.json
+++ b/src/main/resources/data/create/tags/blocks/brittle.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "conditions": [
+    {
+      "modid": "create",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "values": ["cookingforblockheads:fridge"]
+}


### PR DESCRIPTION
Create provides the `brittle` block tag by default which prevents their mod from moving the Tile Entities with this tag.
This commit simply adds this tag to the Fridge to prevent moving it and cause a dupe.
It's a conditional tag and is only added if the Create mod is actually loaded which should prevent further issues.

fixes #536