### PR TITLE
Added a mod blacklist to prevent ingredients to show up in recipe book

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/CookingForBlockheadsConfig.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/CookingForBlockheadsConfig.java
@@ -1,7 +1,10 @@
 package net.blay09.mods.cookingforblockheads;
 
+import com.google.common.collect.Lists;
 import net.minecraftforge.common.ForgeConfigSpec;
 import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.List;
 
 public class CookingForBlockheadsConfig {
 
@@ -15,6 +18,7 @@ public class CookingForBlockheadsConfig {
         public final ForgeConfigSpec.DoubleValue ovenFuelTimeMultiplier;
         public final ForgeConfigSpec.DoubleValue ovenCookTimeMultiplier;
         public final ForgeConfigSpec.BooleanValue ovenRequiresCookingOil;
+        public final ForgeConfigSpec.ConfigValue<List<? extends String>> modBlacklist;
 
         public Common(ForgeConfigSpec.Builder builder) {
             cowJarEnabled = builder
@@ -61,6 +65,11 @@ public class CookingForBlockheadsConfig {
                     .comment("Set this to true if you'd like the oven to only accept cooking oil as fuel (requires Pam's Harvestcraft)")
                     .translation("waystones.config.ovenRequiresCookingOil")
                     .define("ovenRequiresCookingOil", false);
+
+            modBlacklist = builder
+                    .comment("A list of mod namespaces from which you wouldn't like to see ingredients listed in the recipe book")
+                    .translation("waystones.config.modBlacklist")
+                    .defineList("modBlacklist", Lists.newArrayList(""), s -> s instanceof String);
         }
     }
 

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/CookingRegistry.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/CookingRegistry.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import net.blay09.mods.cookingforblockheads.CookingForBlockheads;
+import net.blay09.mods.cookingforblockheads.CookingForBlockheadsConfig;
 import net.blay09.mods.cookingforblockheads.KitchenMultiBlock;
 import net.blay09.mods.cookingforblockheads.api.*;
 import net.blay09.mods.cookingforblockheads.api.capability.IKitchenItemProvider;
@@ -32,6 +33,7 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class CookingRegistry {
 
@@ -57,8 +59,11 @@ public class CookingRegistry {
 
         nonFoodRecipes = init.getNonFoodRecipes();
 
+        Collection<IRecipe<?>> recipes = recipeManager.getRecipes().stream()
+                .filter(recipe -> !CookingForBlockheadsConfig.COMMON.modBlacklist.get().contains(recipe.getId().getNamespace())).collect(Collectors.toSet());
+
         // Crafting Recipes of Food Items
-        for (IRecipe recipe : recipeManager.getRecipes()) {
+        for (IRecipe recipe : recipes) {
             // Skip smoking and campfire cooking to prevent duplicate recipes
             if (recipe.getType() == IRecipeType.SMOKING || recipe.getType() == IRecipeType.CAMPFIRE_COOKING) {
                 continue;
@@ -234,7 +239,8 @@ public class CookingRegistry {
     public static List<SourceItem> findSourceCandidates(FoodIngredient ingredient, List<IKitchenItemProvider> inventories, boolean requireBucket, boolean isNoFilter) {
         List<SourceItem> sourceList = new ArrayList<>();
 
-        ItemStack[] variants = ingredient.getItemStacks();
+        List<ItemStack> variants = Arrays.stream(ingredient.getItemStacks())
+                .filter(i -> !CookingForBlockheadsConfig.COMMON.modBlacklist.get().contains(i.getItem().getRegistryName().getNamespace())).collect(Collectors.toList());
         for (ItemStack checkStack : variants) {
             SourceItem sourceItem = CookingRegistry.findAnyItemStack(checkStack, inventories, requireBucket);
             ItemStack foundStack = sourceItem != null ? sourceItem.getSourceStack() : ItemStack.EMPTY;


### PR DESCRIPTION
Hi @blay09 

I recently installed mods that include new recipes to my Minecraft server. All of the sudden I started to see weird ingredients in the No Filter recipe book. I added this functionality to prevent that from happening so anyone, even personal or server worlds can decide if they want to see those in ingredients in the recipe book.