### PR TITLE
Adding annotation so AttachCapabilitiesEvent is fired

### DIFF
--- a/forge/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
+++ b/forge/src/main/java/net/blay09/mods/cookingforblockheads/compat/CompatCapabilityLoader.java
@@ -2,7 +2,9 @@ package net.blay09.mods.cookingforblockheads.compat;
 
 import net.blay09.mods.cookingforblockheads.CookingForBlockheads;
 import net.blay09.mods.cookingforblockheads.ForgeCookingForBlockheads;
-import net.blay09.mods.cookingforblockheads.api.capability.*;
+import net.blay09.mods.cookingforblockheads.api.capability.DefaultKitchenConnector;
+import net.blay09.mods.cookingforblockheads.api.capability.IKitchenConnector;
+import net.blay09.mods.cookingforblockheads.api.capability.IKitchenItemProvider;
 import net.blay09.mods.cookingforblockheads.compat.json.JsonCompatLoader;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
@@ -12,12 +14,14 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
+@Mod.EventBusSubscriber(modid = CookingForBlockheads.MOD_ID)
 public class CompatCapabilityLoader {
 
     private static KitchenConnectorCapabilityProvider connectorCapabilityProvider;


### PR DESCRIPTION
Added the EventBusSubscriber annotation so AttachCapabilitiesEvent is picked up for compat capabilities.

This fixes https://github.com/ModdingForBlockheads/CookingForBlockheads/issues/613