### PR TITLE
prevents recipe conflicts with macaws paths

### DIFF
--- a/shared/src/main/resources/data/cookingforblockheads/recipes/spice_rack.json
+++ b/shared/src/main/resources/data/cookingforblockheads/recipes/spice_rack.json
@@ -2,10 +2,13 @@
   "result": {
     "item": "cookingforblockheads:spice_rack"
   },
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "SS"
+  ],
+  "key": {
+    "S": {
       "tag": "minecraft:wooden_slabs"
     }
-  ]
+  }
 }


### PR DESCRIPTION
There are no default recipes which take 2 slabs horizontally. 

macaws paths use 1 slab for wooden paths, this create a conflict. 

Personally i think changing the spice rack to 2 slabs makes more sense and solves that conflict.