### PR TITLE
add datagen for colored kitchen floor blocks

### DIFF
--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/black_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/black_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/black_kitchen_floor",
+    "particle": "cookingforblockheads:block/black_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/blue_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/blue_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/blue_kitchen_floor",
+    "particle": "cookingforblockheads:block/blue_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/brown_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/brown_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/brown_kitchen_floor",
+    "particle": "cookingforblockheads:block/brown_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/cyan_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/cyan_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/cyan_kitchen_floor",
+    "particle": "cookingforblockheads:block/cyan_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/gray_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/gray_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/gray_kitchen_floor",
+    "particle": "cookingforblockheads:block/gray_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/green_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/green_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/green_kitchen_floor",
+    "particle": "cookingforblockheads:block/green_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/light_blue_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/light_blue_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/light_blue_kitchen_floor",
+    "particle": "cookingforblockheads:block/light_blue_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/light_gray_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/light_gray_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/light_gray_kitchen_floor",
+    "particle": "cookingforblockheads:block/light_gray_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/lime_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/lime_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/lime_kitchen_floor",
+    "particle": "cookingforblockheads:block/lime_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/magenta_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/magenta_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/magenta_kitchen_floor",
+    "particle": "cookingforblockheads:block/magenta_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/orange_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/orange_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/orange_kitchen_floor",
+    "particle": "cookingforblockheads:block/orange_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/pink_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/pink_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/pink_kitchen_floor",
+    "particle": "cookingforblockheads:block/pink_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/purple_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/purple_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/purple_kitchen_floor",
+    "particle": "cookingforblockheads:block/purple_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/red_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/red_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/red_kitchen_floor",
+    "particle": "cookingforblockheads:block/red_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/white_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/white_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/white_kitchen_floor",
+    "particle": "cookingforblockheads:block/white_kitchen_floor"
+  }
+}

--- a/common/src/generated/resources/assets/cookingforblockheads/models/block/yellow_kitchen_floor.json
+++ b/common/src/generated/resources/assets/cookingforblockheads/models/block/yellow_kitchen_floor.json
@@ -1,0 +1,7 @@
+{
+  "parent": "cookingforblockheads:block/kitchen_floor",
+  "textures": {
+    "all": "cookingforblockheads:block/yellow_kitchen_floor",
+    "particle": "cookingforblockheads:block/yellow_kitchen_floor"
+  }
+}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/black_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/black_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/black_kitchen_floor",
-		"particle": "cookingforblockheads:block/black_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/blue_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/blue_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/blue_kitchen_floor",
-		"particle": "cookingforblockheads:block/blue_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/brown_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/brown_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/brown_kitchen_floor",
-		"particle": "cookingforblockheads:block/brown_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/cyan_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/cyan_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/cyan_kitchen_floor",
-		"particle": "cookingforblockheads:block/cyan_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/gray_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/gray_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/gray_kitchen_floor",
-		"particle": "cookingforblockheads:block/gray_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/green_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/green_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/green_kitchen_floor",
-		"particle": "cookingforblockheads:block/green_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/light_blue_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/light_blue_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/light_blue_kitchen_floor",
-		"particle": "cookingforblockheads:block/light_blue_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/light_gray_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/light_gray_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/light_gray_kitchen_floor",
-		"particle": "cookingforblockheads:block/light_gray_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/lime_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/lime_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/lime_kitchen_floor",
-		"particle": "cookingforblockheads:block/lime_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/magenta_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/magenta_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/magenta_kitchen_floor",
-		"particle": "cookingforblockheads:block/magenta_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/orange_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/orange_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/orange_kitchen_floor",
-		"particle": "cookingforblockheads:block/orange_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/pink_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/pink_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/pink_kitchen_floor",
-		"particle": "cookingforblockheads:block/pink_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/purple_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/purple_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/purple_kitchen_floor",
-		"particle": "cookingforblockheads:block/purple_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/red_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/red_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/red_kitchen_floor",
-		"particle": "cookingforblockheads:block/red_kitchen_floor"
-	}
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/white_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/white_kitchen_floor.json
@@ -1,3 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor"
-}

--- a/common/src/main/resources/assets/cookingforblockheads/models/block/yellow_kitchen_floor.json
+++ b/common/src/main/resources/assets/cookingforblockheads/models/block/yellow_kitchen_floor.json
@@ -1,7 +1,0 @@
-{
-	"parent": "cookingforblockheads:block/kitchen_floor",
-	"textures": {
-		"all": "cookingforblockheads:block/yellow_kitchen_floor",
-		"particle": "cookingforblockheads:block/yellow_kitchen_floor"
-	}
-}

--- a/fabric/src/main/java/net/blay09/mods/cookingforblockheads/fabric/datagen/ModModelProvider.java
+++ b/fabric/src/main/java/net/blay09/mods/cookingforblockheads/fabric/datagen/ModModelProvider.java
@@ -1,6 +1,6 @@
 package net.blay09.mods.cookingforblockheads.fabric.datagen;
 
-import net.blay09.mods.cookingforblockheads.block.ConnectorBlock;
+import net.blay09.mods.cookingforblockheads.CookingForBlockheads;
 import net.blay09.mods.cookingforblockheads.block.DyedConnectorBlock;
 import net.blay09.mods.cookingforblockheads.block.ModBlocks;
 import net.blay09.mods.cookingforblockheads.block.OvenBlock;
@@ -49,12 +49,16 @@ public class ModModelProvider extends FabricModelProvider {
         blockStateModelGenerator.createNonTemplateModelBlock(ModBlocks.sink);
         blockStateModelGenerator.createNonTemplateModelBlock(ModBlocks.counter);
         blockStateModelGenerator.createNonTemplateModelBlock(ModBlocks.cabinet);
-        for (final var kitchenFloor : ModBlocks.kitchenFloors) {
-            blockStateModelGenerator.createNonTemplateModelBlock(kitchenFloor);
-        }
         createConnector(blockStateModelGenerator, ModBlocks.connector);
         for (final var connector : ModBlocks.connectors) {
             createConnector(blockStateModelGenerator, connector);
+        }
+
+        final var kitchenFloorParent = new ModelTemplate(Optional.of(new ResourceLocation(CookingForBlockheads.MOD_ID, "block/kitchen_floor")),
+                Optional.empty(), TextureSlot.ALL, TextureSlot.PARTICLE);
+        for (final var kitchenFloor : ModBlocks.kitchenFloors) {
+            kitchenFloorParent.create(kitchenFloor, TextureMapping.cube(kitchenFloor), blockStateModelGenerator.modelOutput);
+            blockStateModelGenerator.createNonTemplateModelBlock(kitchenFloor);
         }
 
         blockStateModelGenerator.createNonTemplateHorizontalBlock(ModBlocks.toolRack);


### PR DESCRIPTION
This PR adds datagen for kitchen floor block models. And because I ran the data generation task, a few recipes were changed as well since you did update the tags in Balm, but didn't run the task in Cooking for Blockheads again.

<details>
<summary>
Here's my buddy. If you see 2, drink less
</summary>

![2024-05-23_21 37 03](https://github.com/TwelveIterationMods/CookingForBlockheads/assets/26039509/d0d6efc6-36aa-423d-88b6-c50e142a1faf)

</details>